### PR TITLE
Initiate profiling ID early

### DIFF
--- a/src/Xhgui/Profiles.php
+++ b/src/Xhgui/Profiles.php
@@ -8,6 +8,11 @@ class Xhgui_Profiles
 
     protected $_mapper;
 
+    /**
+     * @var MongoId lastProfilingId
+     */
+    private static $lastProfilingId;
+
     public function __construct(MongoDb $db)
     {
         $this->_collection = $db->results;
@@ -22,6 +27,18 @@ class Xhgui_Profiles
      */
     public function insert($profile)
     {
+        $profile['_id'] = self::getLastProfilingId();
         return $this->_collection->insert($profile, array('w' => 0));
+    }
+
+    /**
+     * Return profiling ID
+     * @return MongoId lastProfilingId
+     */
+    public static function getLastProfilingId() {
+        if (!self::$lastProfilingId) {
+            self::$lastProfilingId = new MongoId();
+        }
+        return self::$lastProfilingId;
     }
 }


### PR DESCRIPTION
Initiate profiling id in `Xhgui_Saver` class constructor. That allows to use the same profiling ID throughout your request and profiler results can be easily mapped back to the areas, where this ID is used.
