### PR TITLE
Easier configuration and usage of composer library 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /tags
 /vendor
 config/config.php
+
+# phpstorm files
+.idea/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@ This table represents current known information about compatibility between this
 You can use this to build your own saving library or just configure as described in [XHGUI][2] manual
 and include `external/header.php` as an auto_prepend_file (also described in [XHGUI][2] manual)
 
+### Use with environment variables
+* run `composer require perftools/xhgui-collector` 
+* include these lines into your bootstrap file (e.g. index.php) 
+
+```
+define('XHGUI_CONFIG_DIR', PATH_TO_OWN_CONFIG);
+require_once PATH_TO_YOUR_VENDOR . '/perftools/xhgui-collector/external/header.php';
+```
+ 
+* set environment variables to configure the mongodb host, database name and more
+
+| env | description | example | default |
+| ---- | ----------- | ------- | ------- |
+| `XHGUI_MONGO_URI` | the host and port to the mongo db | `XHGUI_MONGO_URI=mongo:27017` | 127.0.0.1:27017 |
+| `XHGUI_MONGO_DB` | the database name for the profiling data | `XHGUI_MONGO_DB=xhprof` | xhprof |
+| `XHGUI_PROFILING_RATIO` | the ratio of profiled requests | `XHGUI_PROFILING_RATIO=50` which profiles 50% of all requests | `XHGUI_PROFILING_RATIO=100` |
+| `XHGUI_PROFILING` | if this env var is set with any value the profiling is enabled | `XHGUI_PROFILING=enabled` | it is not set per default, so no profiling will be triggered |
+
+
 ## System Requirements
 
 For using the data collection classes you will need the following:

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -2,6 +2,11 @@
 /**
  * Default configuration for Xhgui
  */
+
+$mongoUri = getenv('XHGUI_MONGO_URI') ?: '127.0.0.1:27017';
+$mongoUri = str_replace('mongodb://', '', $mongoUri);
+$mongoDb  = getenv('XHGUI_MONGO_DB') ?: 'xhprof';
+
 return array(
     'debug' => false,
     'mode' => 'development',
@@ -16,8 +21,8 @@ return array(
     // Needed for file save handler. Beware of file locking. You can adujst this file path 
     // to reduce locking problems (eg uniqid, time ...)
     //'save.handler.filename' => __DIR__.'/../data/xhgui_'.date('Ymd').'.dat',
-    'db.host' => 'mongodb://127.0.0.1:27017',
-    'db.db' => 'xhprof',
+    'db.host' => sprintf('mongodb://%s', $mongoUri),
+    'db.db' => $mongoDb,
 
     // Allows you to pass additional options like replicaSet to MongoClient.
     // 'username', 'password' and 'db' (where the user is added)
@@ -27,14 +32,17 @@ return array(
     'detail.count' => 6,
     'page.limit' => 25,
 
-    // Profile 1 in 100 requests.
+    // Profile x in 100 requests. (E.g. set XHGUI_PROFLING_RATIO=50 to profile 50% of requests)
     // You can return true to profile every request.
     'profiler.enable' => function() {
-        return rand(1, 100) === 42;
+        $ratio = getenv('XHGUI_PROFILING_RATIO') ?: 100;
+        return (getenv('XHGUI_PROFILING') !== false) && (mt_rand(1, 100) <= $ratio);
     },
 
     'profiler.simple_url' => function($url) {
         return preg_replace('/\=\d+/', '', $url);
-    }
+    },
+
+    'profiler.options' => array(),
 
 );

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -5,20 +5,20 @@
 
 $mongoUri = getenv('XHGUI_MONGO_URI') ?: '127.0.0.1:27017';
 $mongoUri = str_replace('mongodb://', '', $mongoUri);
-$mongoDb  = getenv('XHGUI_MONGO_DB') ?: 'xhprof';
+$mongoDb = getenv('XHGUI_MONGO_DB') ?: 'xhprof';
 
 return array(
     'debug' => false,
     'mode' => 'development',
 
     // Can be either mongodb or file.
-    /* 
+    /*
     'save.handler' => 'file',
     'save.handler.filename' => dirname(__DIR__) . '/cache/' . 'xhgui.data.' . microtime(true) . '_' . substr(md5($url), 0, 6),
     */
     'save.handler' => 'mongodb',
 
-    // Needed for file save handler. Beware of file locking. You can adujst this file path 
+    // Needed for file save handler. Beware of file locking. You can adujst this file path
     // to reduce locking problems (eg uniqid, time ...)
     //'save.handler.filename' => __DIR__.'/../data/xhgui_'.date('Ymd').'.dat',
     'db.host' => sprintf('mongodb://%s', $mongoUri),

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -10,7 +10,12 @@ if (file_exists(XHGUI_ROOT_DIR . '/vendor/autoload.php')) {
     require XHGUI_ROOT_DIR . '/../../autoload.php';
 }
 
-Xhgui_Config::load(XHGUI_ROOT_DIR . '/config/config.default.php');
-if (file_exists(XHGUI_ROOT_DIR . '/config/config.php')) {
-    Xhgui_Config::load(XHGUI_ROOT_DIR . '/config/config.php');
+$dir = dirname(__DIR__);
+require_once $dir . '/src/Xhgui/Config.php';
+$configDir = defined('XHGUI_CONFIG_DIR') ? XHGUI_CONFIG_DIR : $dir . '/config/';
+if (file_exists($configDir . 'config.php')) {
+    Xhgui_Config::load($configDir . 'config.php');
+} else {
+    Xhgui_Config::load($configDir . 'config.default.php');
 }
+unset($dir, $configDir);


### PR DESCRIPTION
(add) | profiler options which are already implemented in perftools/xhgui
(add) | env vars for some configuration entries to make a use with docker more pleasant
(add) | introduce XHGUI_CONFIG_DIR constant as way to set the location of your xhgui config.php
(update) | readme

With these changes your are able to set your own config dir when requiring the header.php in the application.
You can run your application in docker container and start the profiling via env var or set the an env var to change the profiling rate.