### PR TITLE
Flush output for fastcgi SAPI

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -125,6 +125,9 @@ register_shutdown_function(
         // since we're delaying that a bit by dealing with the xhprof stuff, we'll do it now to avoid making the user wait.
         ignore_user_abort(true);
         flush();
+        if (function_exists('fastcgi_finish_request')) {
+            fastcgi_finish_request();
+        }
 
         if (!defined('XHGUI_ROOT_DIR')) {
             require dirname(dirname(__FILE__)) . '/src/bootstrap.php';


### PR DESCRIPTION
Unfortunately, current realization of premature response sending  
```
flush();
```
forgets about fastcgi sapi :) 
So, now it is fixed 
ps. My realization is copy-pasted from https://github.com/symfony/http-foundation/blob/master@%7B2018-07-25T16:24:46Z%7D/Response.php#L371