### PR TITLE
Close session before flushing response

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -124,6 +124,9 @@ register_shutdown_function(
         // flush() asks PHP to send any data remaining in the output buffers. This is normally done when the script completes, but
         // since we're delaying that a bit by dealing with the xhprof stuff, we'll do it now to avoid making the user wait.
         ignore_user_abort(true);
+        if (function_exists('session_write_close')) {
+            session_write_close();
+        }
         flush();
         if (function_exists('fastcgi_finish_request')) {
             fastcgi_finish_request();


### PR DESCRIPTION
Sometimes flushing request can lead to an unexpected consequence: next request is issued before the previous one has written data into the session.
The issue I stumbled upon happens on login into an application: shutdown handler flushes response to login request (which is a redirect), and a browser follows it. However, session is written only when profiling data has been sent which could later than the next request reaches the server which basically makes it look as if logging in doesn't work at all.
Closing the session before flushing response works for me, and I hope it fixes some other weird cases.