### PR TITLE
setup .gitattributes to limit git export files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# general excludes
+/.gitignore export-ignore
+/.gitmodules export-ignore
+
+# maintenance tools
+/.scrutinizer.yml export-ignore


### PR DESCRIPTION
skips unwanted files from git export, visible when installing `composer --prefer-dist`

- `.gitattributes`
- `.gitignore`
- `.scrutinizer.yml`