### PR TITLE
Added custom method to filter urls

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -55,6 +55,10 @@ return array(
     'profiler.simple_url' => function($url) {
         return preg_replace('/\=\d+/', '', $url);
     },
+    
+    //'profiler.replace_url' => function($url) {
+    //    return str_replace('token', '', $url);
+    //},
 
     'profiler.options' => array(),
 );

--- a/external/header.php
+++ b/external/header.php
@@ -144,6 +144,10 @@ register_shutdown_function(
             $cmd = basename($_SERVER['argv'][0]);
             $uri = $cmd . ' ' . implode(' ', array_slice($_SERVER['argv'], 1));
         }
+        
+        if (function_exists('custom_validate_url')) {
+            $uri = custom_validate_url($uri);
+        }
 
         $time = array_key_exists('REQUEST_TIME', $_SERVER)
             ? $_SERVER['REQUEST_TIME']

--- a/external/header.php
+++ b/external/header.php
@@ -145,9 +145,9 @@ register_shutdown_function(
             $uri = $cmd . ' ' . implode(' ', array_slice($_SERVER['argv'], 1));
         }
         
-        $clean_url = Xhgui_Config::read('profiler.clean_url');
-        if (is_callable($clean_url)) {
-            $uri = $clean_url($uri);
+        $replace_url = Xhgui_Config::read('profiler.replace_url');
+        if (is_callable($replace_url)) {
+            $uri = $replace_url($uri);
         }
 
         $time = array_key_exists('REQUEST_TIME', $_SERVER)

--- a/external/header.php
+++ b/external/header.php
@@ -145,8 +145,8 @@ register_shutdown_function(
             $uri = $cmd . ' ' . implode(' ', array_slice($_SERVER['argv'], 1));
         }
         
-        if (function_exists('custom_validate_url')) {
-            $uri = custom_validate_url($uri);
+        if (function_exists('custom_clean_url')) {
+            $uri = custom_clean_url($uri);
         }
 
         $time = array_key_exists('REQUEST_TIME', $_SERVER)

--- a/external/header.php
+++ b/external/header.php
@@ -145,8 +145,9 @@ register_shutdown_function(
             $uri = $cmd . ' ' . implode(' ', array_slice($_SERVER['argv'], 1));
         }
         
-        if (function_exists('custom_clean_url')) {
-            $uri = custom_clean_url($uri);
+        $clean_url = Xhgui_Config::read('profiler.clean_url');
+        if (is_callable($clean_url)) {
+            $uri = $clean_url($uri);
         }
 
         $time = array_key_exists('REQUEST_TIME', $_SERVER)


### PR DESCRIPTION
This patch eanble with a custom function in `config.php` to clean up the url from parameters:

```
    'profiler.clean_url' => function($uri) {
        $uri = str_replace('?enable-tideways', '', $uri);
        $uri = str_replace('%3Fenable-tideways', '', $uri);
        return $uri;
    }
```