### PR TITLE
invalid document for insert: keys cannot contain "."

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -118,6 +118,12 @@ register_shutdown_function(
         } else {
             $data['profile'] = xhprof_disable();
         }
+        
+        $profile = [];
+        foreach($data['profile'] as $key => $value) {
+            $profile[strtr($key, ['.' => '_'])] = $value;
+        }
+        $data['profile'] = $profile;
 
         // ignore_user_abort(true) allows your PHP script to continue executing, even if the user has terminated their request.
         // Further Reading: http://blog.preinheimer.com/index.php?/archives/248-When-does-a-user-abort.html


### PR DESCRIPTION
See https://github.com/perftools/xhgui/issues/209#issuecomment-339281276

`invalid document for insert: keys cannot contain ".": "main()==>load::admin/index.php"`