### PR TITLE
Skipping built-in functions

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -68,4 +68,6 @@ return array(
     //},
 
     'profiler.options' => array(),
+
+    'profiler.skip_built_in' => false,
 );


### PR DESCRIPTION
This patch adds the `profiler.skip_built_in` configuration parameter. See #32 

I decided to introduce such option, since having `profiler.flags` turned out to not make much sense and being prone to errors.
For instance, if someone were to use extra flags from the `tideways_xhprof` extension, it would fail because XHGui doesn't support this data.
But all of the extensions have their own `NO_BUILTINS` flag, so it's the best way I could think of.