### PR TITLE
Escape profile keys for MongoDB

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -144,6 +144,14 @@ register_shutdown_function(
         } else {
             $data['profile'] = xhprof_disable();
         }
+        
+        // Escape profile data keys according to the standard https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
+        $profile = [];
+        foreach ($data['profile'] as $key => $data) {
+            $escapedKey = str_replace([".", "$"], "_", $key);
+            $profile[$escapedKey] = $data;
+        }
+        $data['profile'] = $profile;
 
         // ignore_user_abort(true) allows your PHP script to continue executing, even if the user has terminated their request.
         // Further Reading: http://blog.preinheimer.com/index.php?/archives/248-When-does-a-user-abort.html

--- a/external/header.php
+++ b/external/header.php
@@ -144,14 +144,6 @@ register_shutdown_function(
         } else {
             $data['profile'] = xhprof_disable();
         }
-        
-        // Escape profile data keys according to the standard https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
-        $profile = [];
-        foreach ($data['profile'] as $key => $data) {
-            $escapedKey = str_replace([".", "$"], "_", $key);
-            $profile[$escapedKey] = $data;
-        }
-        $data['profile'] = $profile;
 
         // ignore_user_abort(true) allows your PHP script to continue executing, even if the user has terminated their request.
         // Further Reading: http://blog.preinheimer.com/index.php?/archives/248-When-does-a-user-abort.html

--- a/src/Xhgui/Saver/Mongo.php
+++ b/src/Xhgui/Saver/Mongo.php
@@ -23,6 +23,16 @@ class Xhgui_Saver_Mongo implements Xhgui_Saver_Interface
             $data['_id'] = self::getLastProfilingId();
         }
 
+        // Escape profile data keys according to the standard https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
+        if (isset($data['profile'])) {
+            $profile = array();
+            foreach ($data['profile'] as $key => $data) {
+                $escapedKey = str_replace(array(".", "$"), "_", $key);
+                $profile[$escapedKey] = $data;
+            }
+            $data['profile'] = $profile;
+        }
+
         if (isset($data['meta']['request_ts'])) {
             $data['meta']['request_ts'] = new MongoDate($data['meta']['request_ts']['sec']);
         }

--- a/src/Xhgui/Saver/Mongo.php
+++ b/src/Xhgui/Saver/Mongo.php
@@ -25,12 +25,11 @@ class Xhgui_Saver_Mongo implements Xhgui_Saver_Interface
 
         // Escape profile data keys according to the standard https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
         if (isset($data['profile'])) {
-            $profile = array();
             foreach ($data['profile'] as $key => $data) {
                 $escapedKey = str_replace(array(".", "$"), "_", $key);
-                $profile[$escapedKey] = $data;
+                $data['profile'][$escapedKey] = $data;
+                unset($data['profile'][$key]);
             }
-            $data['profile'] = $profile;
         }
 
         if (isset($data['meta']['request_ts'])) {

--- a/src/Xhgui/Saver/Mongo.php
+++ b/src/Xhgui/Saver/Mongo.php
@@ -26,9 +26,9 @@ class Xhgui_Saver_Mongo implements Xhgui_Saver_Interface
         // Escape profile data keys according to the standard https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
         if (isset($data['profile'])) {
             $profile = array();
-            foreach ($data['profile'] as $key => $data) {
+            foreach ($data['profile'] as $key => $value) {
                 $escapedKey = str_replace(array(".", "$"), "_", $key);
-                $profile[$escapedKey] = $data;
+                $profile[$escapedKey] = $value;
             }
             $data['profile'] = $profile;
             unset($profile);

--- a/src/Xhgui/Saver/Mongo.php
+++ b/src/Xhgui/Saver/Mongo.php
@@ -25,11 +25,13 @@ class Xhgui_Saver_Mongo implements Xhgui_Saver_Interface
 
         // Escape profile data keys according to the standard https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names
         if (isset($data['profile'])) {
+            $profile = array();
             foreach ($data['profile'] as $key => $data) {
                 $escapedKey = str_replace(array(".", "$"), "_", $key);
-                $data['profile'][$escapedKey] = $data;
-                unset($data['profile'][$key]);
+                $profile[$escapedKey] = $data;
             }
+            $data['profile'] = $profile;
+            unset($profile);
         }
 
         if (isset($data['meta']['request_ts'])) {


### PR DESCRIPTION
In some situations the names of the php files are sent to Mongo and mongo returns an error like:
**xhgui - invalid document for insert: keys cannot contain ".": "main()==>load::lib/paths_constants.php"**

According to the standard https://docs.mongodb.com/manual/reference/limits/#Restrictions-on-Field-Names cannot insert keys that contain dots or $